### PR TITLE
Add fsGroup

### DIFF
--- a/kubernetes/qdbd.yaml
+++ b/kubernetes/qdbd.yaml
@@ -102,8 +102,9 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
 
-        securityContext:
-          runAsUser: 999
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
 
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
Depending on the underlying volume storage backend the mounted volume might not be accessible for user 999.

- Move `securityContext` out of  `containers`
- Add `fsGroup: 999` to ensure write access to the persistent volumes